### PR TITLE
fix ics, duration invalid strings

### DIFF
--- a/apps/web-app/pages/api/ics.tsx
+++ b/apps/web-app/pages/api/ics.tsx
@@ -37,17 +37,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .order("startTime", { ascending: true })
         if (response.error === null) {
             const cal = ical({
-                prodId: '//superman-industries.com//ical-generator//EN',
+                prodId: '//zuzalu.city//sessions//EN',
                 events: response.data.map((session: any) => {
                     const sessionStartDate = new Date(`${session.startDate}T${session.startTime}`);
-                    const sessionEndDate = new Date(sessionStartDate.getTime() + session.duration * 60000); // add session duration in minutes
+                    let duration = parseFloat(session.duration);
+                    if (isNaN(duration)) {
+                        duration = parseFloat(session.duration.replace(/[^0-9]/g, ''));
+                    }
+                    const sessionEndDate = new Date(sessionStartDate.getTime() + duration * 60000); // add session duration in minutes
                     const description = `Location: ${session.location}\n\nTags: ${JSON.stringify(session.tags)}\n\nTrack: ${session.track}\n\nFormat: ${session.format}\n\nLevel: ${session.level}\n\n${session.description}\n\n\n\nMore Info: https://zuzalu.city/event/${session.event_id}/session/${session.id}`;
-                        const url = `https://zuzalu.city/event/${session.event_id}/session/${session.id}`
+                    const url = `https://zuzalu.city/event/${session.event_id}/session/${session.id}`
 
-                        return {
+                    return {
                         start: sessionStartDate,
                         end: sessionEndDate,
-                        summary: `[${session.session_slug}] ${session.name} (${session.session_type})`,
+                        summary: `[${session.event_slug}] ${session.name} (${session.event_type})`,
                         description,
                         location: session.location,
                         url


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

> error:  Error: `end` has to be a valid date!

https://vercel.com/zuzalu-org/taz-zulalu-web-app/DyCWSKBAsya7b1xNktcsc5RZRmyB/logs?page=1&timeline=past30Minutes&startDate=1681906076908&endDate=1681907876908&selectedLogId=1681907876908729969535128447&selectedLogTimestamp=1681907876908&forceEndDate=1681907876908

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
