### PR TITLE
updated Event Types to work with Lecture type

### DIFF
--- a/apps/web-app/components/AddSessionModal/Step1.tsx
+++ b/apps/web-app/components/AddSessionModal/Step1.tsx
@@ -546,9 +546,6 @@ const Step1 = ({ newSession, setNewSession, setSteps, sessions }: Props) => {
                                 {item.type}
                             </option>
                         ))}
-                    <option value="Workshop">Workshop</option>
-                    <option value="Lecture">Lecture</option>
-                    <option value="Other">Other</option>
                 </select>
             </div>
             <div className="flex flex-col gap-1 my-2">

--- a/apps/web-app/components/CalendarSessionModal/Step2.tsx
+++ b/apps/web-app/components/CalendarSessionModal/Step2.tsx
@@ -552,9 +552,6 @@ const Step2 = ({ newSession, setNewSession, setSteps, sessions }: Props) => {
                                 {item.type}
                             </option>
                         ))}
-                    <option value="Workshop">Workshop</option>
-                    <option value="Lecture">Lecture</option>
-                    <option value="Other">Other</option>
                 </select>
             </div>
             <div className="flex flex-col gap-1 my-2">

--- a/apps/web-app/components/EditSessionModal/Step1.tsx
+++ b/apps/web-app/components/EditSessionModal/Step1.tsx
@@ -579,9 +579,6 @@ const Step1 = ({ newSession, setNewSession, setSteps, sessions, sessionId }: Pro
                                 {item.type}
                             </option>
                         ))}
-                    <option value="Workshop">Workshop</option>
-                    <option value="Lecture">Lecture</option>
-                    <option value="Other">Other</option>
                 </select>
             </div>
             <div className="flex flex-col gap-1 my-2">


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->
Added Lecture to the event_types table in Supabase, which will automatically get fetched into the frontend. That's why I removed the extra options "Workshop", "Other" and "Lecture", as they're already being pulled from the database.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
